### PR TITLE
Fingerprint

### DIFF
--- a/src/tutorial/webauthn.js
+++ b/src/tutorial/webauthn.js
@@ -38,7 +38,8 @@ export async function login(rawId, timeout) {
       timeout,
       allowCredentials: [{
         type: 'public-key',
-        id: rawId
+        id: rawId,
+        transports: ['usb', 'internal']
       }]
     }
   });

--- a/views/tutorial/step-4-allow-credentials.html
+++ b/views/tutorial/step-4-allow-credentials.html
@@ -3,7 +3,8 @@
 <pre><code>allowCredentials: [
   {
     type: 'public-key',
-    id: <div class="tutorial-step-4-allow-credentials-id-container"><code class="tutorial-step-4-allow-credentials-id-code"></code></div>
+    id: <div class="tutorial-step-4-allow-credentials-id-container"><code class="tutorial-step-4-allow-credentials-id-code"></code></div>,
+    transports: ['usb', 'internal']
   }
 ],</code></pre>
 


### PR DESCRIPTION
When creating credentials, the current implementation - used in Chrome - would let you use the fingerprint sensor.  When authenticating, it would force the USB keys.  By removing the transport property, we can now authenticate by using the fingerprint as well.  

*** Not tested with USB keys though ***