### PR TITLE
Updated browser support to consider iOS 14.5

### DIFF
--- a/views/browser-support/index.pug
+++ b/views/browser-support/index.pug
@@ -119,7 +119,7 @@ block content
         thead
           th
           th Android 7+
-          th iOS 14+
+          th iOS 14.5+
           th Windows 10
           th macOS Catalina 
           th macOS Big Sur
@@ -127,7 +127,7 @@ block content
           tr 
             td Chrome
             td.y Yes
-            td No
+            td.y Yes
             td.y Yes
             td.y Yes
             td.y Yes
@@ -141,7 +141,7 @@ block content
           tr
             td Firefox
             td No
-            td No
+            td.y Yes
             td.y Yes
             td.y Yes
             td.y Yes
@@ -158,7 +158,7 @@ block content
             td No
             td.y Yes
             td.y Yes
-            td  Yes
+            td.y Yes
           tr
             td Internet Explorer
             td N/A


### PR DESCRIPTION
I changed the iOS line from iOS 14+ to iOS 14.5+, and included browsers that are supported in that version.

I could have differentiated between browsers supported in iOS 14.x (x <= 5) and iOS 14.5+, but it did not seem very relevant, and it would have required adding a new column.



