### PR TITLE
Add statistics for desktop linux OSs

### DIFF
--- a/less/browser-support/index.less
+++ b/less/browser-support/index.less
@@ -38,7 +38,7 @@ th {
 
 td {
   padding: 1rem;
-  width: 15%;
+  width: 12.5%;
   border: 1px solid @color-light-gray;
 
   &:first-child {

--- a/views/browser-support/index.pug
+++ b/views/browser-support/index.pug
@@ -71,6 +71,7 @@ block content
                 span.small (with Windows Hello)
               th macOS Catalina
               th macOS Big Sur
+              th Desktop Linux
             tbody 
               tr 
                 td Chrome
@@ -79,6 +80,7 @@ block content
                 td.y Yes
                 td.y Yes
                 td.y Yes
+                td -
               tr
                 td Safari
                 td N/A
@@ -86,6 +88,7 @@ block content
                 td N/A
                 td No
                 td.y Yes
+                td N/A
               tr
                 td Firefox
                 td No
@@ -93,6 +96,7 @@ block content
                 td.y Yes
                 td No
                 td No
+                td -
               tr
                 td Brave
                 td No
@@ -100,18 +104,21 @@ block content
                 td.y Yes
                 td.y Yes
                 td.y Yes
+                td -
               tr
                 td Edge
                 td No
                 td.y Yes
                 td.y Yes
                 td.y Yes
-                td  Yes
+                td.y Yes
+                td -
               tr
                 td Internet Explorer
                 td N/A
                 td N/A
                 td No
+                td N/A
                 td N/A
                 td N/A
 
@@ -127,9 +134,11 @@ block content
               th Windows 10
               th macOS Catalina 
               th macOS Big Sur
+              th Desktop Linux
             tbody 
               tr 
                 td Chrome
+                td.y Yes
                 td.y Yes
                 td.y Yes
                 td.y Yes
@@ -142,9 +151,11 @@ block content
                 td N/A
                 td.y Yes
                 td.y Yes
+                td N/A
               tr
                 td Firefox
                 td No
+                td.y Yes
                 td.y Yes
                 td.y Yes
                 td.y Yes
@@ -156,10 +167,12 @@ block content
                 td.y Yes
                 td.y Yes
                 td.y Yes
+                td.y Yes
               tr
                 td Edge
                 td No
                 td No
+                td.y Yes
                 td.y Yes
                 td.y Yes
                 td.y Yes
@@ -168,6 +181,7 @@ block content
                 td N/A
                 td N/A
                 td No
+                td N/A
                 td N/A
                 td N/A
 


### PR DESCRIPTION
### Description

Add browser support statistics for Linux to the overview tables. The general conclusion is that Chromium-based browsers support roaming authenticators, regardless of OS. We don't have enough data for platform authenticators on Linux.

### References
- Closes #24 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
