### PR TITLE
add NODE_ENV value to pug templates in grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,7 +54,9 @@ module.exports = (grunt) => {
             default: {
                 options: {
                     pretty: true,
-                    data: {},
+                    data: {
+                        NODE_ENV: process.env.NODE_ENV,
+                    },
                 },
                 files: {
                     //'dist/index.html': 'views/index.pug',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "grunt build-prod",
     "start": "node api/index.js",
     "start:dev": "grunt",
-    "build": "grunt build-prod",
+    "build": "NODE_ENV=production grunt build-prod",
     "test": "grunt test"
   },
   "keywords": [

--- a/src/tutorial/index.js
+++ b/src/tutorial/index.js
@@ -15,8 +15,6 @@ if (
   document.querySelector("#tutorial-error-message").classList.remove("hidden");
 }
 
-console.log(process.env.NODE_ENV);
-
 step1.init();
 step2.init();
 step3.init();

--- a/src/tutorial/index.js
+++ b/src/tutorial/index.js
@@ -15,6 +15,8 @@ if (
   document.querySelector("#tutorial-error-message").classList.remove("hidden");
 }
 
+console.log(process.env.NODE_ENV);
+
 step1.init();
 step2.init();
 step3.init();

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -39,6 +39,7 @@ html(lang='en')
     block prefetch
     include prefetch.pug
 
+
     // OneTrustScripts
     if NODE_ENV === "production"
       script(src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js", type="text/javascript", charset="UTF-8", data-domain-script="3cdc400f-b58d-4d3b-83fd-9f22770403da", id="consent-script")
@@ -118,6 +119,10 @@ html(lang='en')
     meta(name="google-site-verification" content="8PENs1ni2zY2-JstEN8PRrMO3N76CRf2r1yP1qMf14M")
 
   body
+    div
+      p The current environment is:
+      strong #{NODE_ENV}
+
     // Google Tag Manager (noscript)
     noscript
       iframe(src="https://www.googletagmanager.com/ns.html?id=GTM-PJZ8DTR2" height="0" width="0" style="display:none;visibility:hidden")

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -119,10 +119,6 @@ html(lang='en')
     meta(name="google-site-verification" content="8PENs1ni2zY2-JstEN8PRrMO3N76CRf2r1yP1qMf14M")
 
   body
-    div
-      p The current environment is:
-      strong #{NODE_ENV}
-
     // Google Tag Manager (noscript)
     noscript
       iframe(src="https://www.googletagmanager.com/ns.html?id=GTM-PJZ8DTR2" height="0" width="0" style="display:none;visibility:hidden")

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -40,10 +40,10 @@ html(lang='en')
     include prefetch.pug
 
     // OneTrustScripts
-    if process.env.NODE_ENV === "production"
+    if NODE_ENV === "production"
       script(src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js", type="text/javascript", charset="UTF-8", data-domain-script="3cdc400f-b58d-4d3b-83fd-9f22770403da", id="consent-script")
-      script(src="/js/ccpa-modal.js")
-      script(src="/js/cookie-consent.js")
+      script(src="js/ccpa-modal.js")
+      script(src="js/cookie-consent.js")
 
     script(type="application/ld+json").
       [{


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The process.env.NODE_ENV variable is not accessible from the pug template. This causes the onetrust scripts not to load and not work as expected. 
This PR passes the NODE_ENV variable to the pug templates in the grunt task.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
